### PR TITLE
feat(secret): add versioned AES-GCM format and YAML scalar fidelity

### DIFF
--- a/pkg/secret/aes_encoder.go
+++ b/pkg/secret/aes_encoder.go
@@ -5,16 +5,35 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
+	"crypto/subtle"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
-	"strings"
+)
+
+const (
+	formatVersionLegacyCBC uint16 = 16
+	formatVersionAesGCM    uint16 = 2
+
+	formatVersionSize = 2
+	gcmNonceSize      = 12
+)
+
+var (
+	errMinimumDataLength        = errors.New("minimum required data length")
+	errUnpadFailed              = errors.New("inconsistent data, unpad failed")
+	errBlockSizeMultiple        = errors.New("data isn't a multiple of the block size")
+	errAuthenticationFailed     = errors.New("authentication failed: data has been tampered with or the encryption key is wrong")
+	errUnsupportedFormatVersion = errors.New("unsupported secret format version")
 )
 
 type AesEncoder struct {
 	CipherBlock cipher.Block
 }
+
+var _ formatAwareDecrypter = (*AesEncoder)(nil)
 
 func GenerateAesSecretKey() ([]byte, error) {
 	randomBytes := make([]byte, 16)
@@ -43,23 +62,20 @@ func NewAesEncoder(key []byte) (*AesEncoder, error) {
 }
 
 func (s *AesEncoder) Encrypt(data []byte) ([]byte, error) {
-	dataToEncrypt := pad(data)
-
-	cipherData := make([]byte, aes.BlockSize+len(dataToEncrypt))
-	iv := cipherData[:aes.BlockSize]
-	if _, err := io.ReadFull(rand.Reader, iv); err != nil {
-		return nil, err
+	gcm, err := cipher.NewGCM(s.CipherBlock)
+	if err != nil {
+		return nil, fmt.Errorf("initialize aes-gcm: %w", err)
 	}
 
-	mode := cipher.NewCBCEncrypter(s.CipherBlock, iv)
-	mode.CryptBlocks(cipherData[aes.BlockSize:], dataToEncrypt)
+	args := make([]byte, formatVersionSize+gcmNonceSize)
+	binary.LittleEndian.PutUint16(args[:formatVersionSize], formatVersionAesGCM)
 
-	ivSize := make([]byte, 2)
-	binary.LittleEndian.PutUint16(ivSize, aes.BlockSize)
+	nonce := args[formatVersionSize:]
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, fmt.Errorf("read random nonce: %w", err)
+	}
 
-	var args []byte
-	args = append(args, ivSize...)
-	args = append(args, cipherData...)
+	args = gcm.Seal(args, nonce, data, nil)
 
 	result := make([]byte, hex.EncodedLen(len(args)))
 	hex.Encode(result, args)
@@ -68,57 +84,104 @@ func (s *AesEncoder) Encrypt(data []byte) ([]byte, error) {
 }
 
 func (s *AesEncoder) Decrypt(data []byte) ([]byte, error) {
+	result, _, err := s.decryptWithFormat(data)
+	return result, err
+}
+
+// Empty input is reported as the legacy format so that callers which restore YAML
+// scalar metadata treat the result as an unframed plain value.
+func (s *AesEncoder) decryptWithFormat(data []byte) ([]byte, uint16, error) {
 	if len(data) == 0 {
-		return data, nil
+		return data, formatVersionLegacyCBC, nil
 	}
 
 	dataToExtract, err := hexToBinary(data)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
-	ivLengthInfoSize := 2
-	ivSize := aes.BlockSize
-	paddingMaxSize := aes.BlockSize
-	minimalDataBinarySize := ivLengthInfoSize + ivSize + paddingMaxSize
-	minimalDataSize := minimalDataBinarySize * 2
-	if len(dataToExtract) < minimalDataBinarySize { // iv + padding
-		return nil, fmt.Errorf("minimum required data length: '%v'", minimalDataSize)
+	if len(dataToExtract) < formatVersionSize {
+		return nil, 0, minimumDataLengthError(legacyCBCMinimumDataBinarySize())
 	}
 
-	iv := dataToExtract[ivLengthInfoSize : ivLengthInfoSize+ivSize]
-	cipherText := dataToExtract[ivLengthInfoSize+ivSize:]
+	version := binary.LittleEndian.Uint16(dataToExtract[:formatVersionSize])
+
+	switch version {
+	case formatVersionLegacyCBC:
+		result, err := s.decryptLegacyCBC(dataToExtract)
+		return result, version, err
+	case formatVersionAesGCM:
+		result, err := s.decryptAesGCM(dataToExtract)
+		return result, version, err
+	default:
+		return nil, version, fmt.Errorf("%w: %d", errUnsupportedFormatVersion, version)
+	}
+}
+
+func (s *AesEncoder) decryptLegacyCBC(dataToExtract []byte) ([]byte, error) {
+	if len(dataToExtract) < legacyCBCMinimumDataBinarySize() {
+		return nil, minimumDataLengthError(legacyCBCMinimumDataBinarySize())
+	}
+
+	iv := dataToExtract[formatVersionSize : formatVersionSize+aes.BlockSize]
+	cipherText := dataToExtract[formatVersionSize+aes.BlockSize:]
 
 	if len(cipherText)%aes.BlockSize != 0 {
-		return nil, fmt.Errorf("data isn't a multiple of the block size")
+		return nil, errBlockSizeMultiple
 	}
 
 	mode := cipher.NewCBCDecrypter(s.CipherBlock, iv)
 	mode.CryptBlocks(cipherText, cipherText)
 
-	result, err := unpad(cipherText)
+	return unpad(cipherText)
+}
+
+func (s *AesEncoder) decryptAesGCM(dataToExtract []byte) ([]byte, error) {
+	gcm, err := cipher.NewGCM(s.CipherBlock)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("initialize aes-gcm: %w", err)
+	}
+
+	minimumDataBinarySize := formatVersionSize + gcmNonceSize + gcm.Overhead()
+	if len(dataToExtract) < minimumDataBinarySize {
+		return nil, minimumDataLengthError(minimumDataBinarySize)
+	}
+
+	nonce := dataToExtract[formatVersionSize : formatVersionSize+gcmNonceSize]
+	cipherText := dataToExtract[formatVersionSize+gcmNonceSize:]
+
+	result, err := gcm.Open(nil, nonce, cipherText, nil)
+	if err != nil {
+		return nil, errAuthenticationFailed
 	}
 
 	return result, nil
 }
 
-func pad(data []byte) []byte {
-	padding := aes.BlockSize - len(data)%aes.BlockSize
-	padtext := bytes.Repeat([]byte{byte(padding)}, padding)
-	return append(data, padtext...)
+func legacyCBCMinimumDataBinarySize() int {
+	return formatVersionSize + aes.BlockSize + aes.BlockSize
+}
+
+func minimumDataLengthError(minimumDataBinarySize int) error {
+	return fmt.Errorf("%w: '%v'", errMinimumDataLength, minimumDataBinarySize*2)
 }
 
 func unpad(data []byte) ([]byte, error) {
 	length := len(data)
-	unpadding := int(data[length-1])
-
-	if unpadding > length {
-		return nil, fmt.Errorf("inconsistent data, unpad failed")
+	if length == 0 {
+		return nil, errUnpadFailed
 	}
 
-	return data[:(length - unpadding)], nil
+	unpadding := int(data[length-1])
+	if unpadding == 0 || unpadding > aes.BlockSize || unpadding > length {
+		return nil, errUnpadFailed
+	}
+
+	if subtle.ConstantTimeCompare(data[length-unpadding:], bytes.Repeat([]byte{byte(unpadding)}, unpadding)) != 1 {
+		return nil, errUnpadFailed
+	}
+
+	return data[:length-unpadding], nil
 }
 
 func hexToBinary(data []byte) ([]byte, error) {
@@ -131,16 +194,7 @@ func hexToBinary(data []byte) ([]byte, error) {
 }
 
 func IsExtractDataError(err error) bool {
-	dataErrorPrefixes := []string{
-		"minimum required data length",
-		"encoding/hex: odd length hex string",
-	}
-
-	for _, prefix := range dataErrorPrefixes {
-		if strings.HasPrefix(err.Error(), prefix) {
-			return true
-		}
-	}
-
-	return false
+	return errors.Is(err, errMinimumDataLength) ||
+		errors.Is(err, hex.ErrLength) ||
+		errors.Is(err, errUnsupportedFormatVersion)
 }

--- a/pkg/secret/aes_encoder.go
+++ b/pkg/secret/aes_encoder.go
@@ -75,7 +75,10 @@ func (s *AesEncoder) Encrypt(data []byte) ([]byte, error) {
 		return nil, fmt.Errorf("read random nonce: %w", err)
 	}
 
-	args = gcm.Seal(args, nonce, data, nil)
+	// The version prefix is authenticated so that it cannot be altered within this
+	// format. It cannot stop a rewrite to the legacy version, which routes to the
+	// unauthenticated CBC reader instead; see the package documentation.
+	args = gcm.Seal(args, nonce, data, args[:formatVersionSize])
 
 	result := make([]byte, hex.EncodedLen(len(args)))
 	hex.Encode(result, args)
@@ -150,7 +153,7 @@ func (s *AesEncoder) decryptAesGCM(dataToExtract []byte) ([]byte, error) {
 	nonce := dataToExtract[formatVersionSize : formatVersionSize+gcmNonceSize]
 	cipherText := dataToExtract[formatVersionSize+gcmNonceSize:]
 
-	result, err := gcm.Open(nil, nonce, cipherText, nil)
+	result, err := gcm.Open(nil, nonce, cipherText, dataToExtract[:formatVersionSize])
 	if err != nil {
 		return nil, errAuthenticationFailed
 	}

--- a/pkg/secret/aes_encoder.go
+++ b/pkg/secret/aes_encoder.go
@@ -19,6 +19,11 @@ const (
 
 	formatVersionSize = 2
 	gcmNonceSize      = 12
+
+	// The sealed data ends with one byte holding how much filler precedes it, which lets
+	// the container size dodge the legacy layout. See fillerSizeFor.
+	gcmFillerSizeLen = 1
+	gcmMaxFillerSize = 1
 )
 
 var (
@@ -75,10 +80,8 @@ func (s *AesEncoder) Encrypt(data []byte) ([]byte, error) {
 		return nil, fmt.Errorf("read random nonce: %w", err)
 	}
 
-	// The version prefix is authenticated so that it cannot be altered within this
-	// format. It cannot stop a rewrite to the legacy version, which routes to the
-	// unauthenticated CBC reader instead; see the package documentation.
-	args = gcm.Seal(args, nonce, data, args[:formatVersionSize])
+	// The version prefix is authenticated so that it cannot be altered within this format.
+	args = gcm.Seal(args, nonce, sealedPlainText(data, gcm.Overhead()), args[:formatVersionSize])
 
 	result := make([]byte, hex.EncodedLen(len(args)))
 	hex.Encode(result, args)
@@ -145,7 +148,7 @@ func (s *AesEncoder) decryptAesGCM(dataToExtract []byte) ([]byte, error) {
 		return nil, fmt.Errorf("initialize aes-gcm: %w", err)
 	}
 
-	minimumDataBinarySize := formatVersionSize + gcmNonceSize + gcm.Overhead()
+	minimumDataBinarySize := gcmContainerSize(0, 0, gcm.Overhead())
 	if len(dataToExtract) < minimumDataBinarySize {
 		return nil, minimumDataLengthError(minimumDataBinarySize)
 	}
@@ -158,7 +161,52 @@ func (s *AesEncoder) decryptAesGCM(dataToExtract []byte) ([]byte, error) {
 		return nil, errAuthenticationFailed
 	}
 
-	return result, nil
+	return unfill(result)
+}
+
+// A container whose size matches the legacy layout could be handed to the CBC reader by
+// rewriting its version prefix, and that reader cannot authenticate. Padding the sealed
+// data by one byte in exactly those cases keeps every version-2 container off the legacy
+// grid, so such a rewrite always fails on size alone.
+func sealedPlainText(data []byte, overhead int) []byte {
+	filler := fillerSizeFor(len(data), overhead)
+
+	result := make([]byte, 0, len(data)+filler+gcmFillerSizeLen)
+	result = append(result, data...)
+	result = append(result, bytes.Repeat([]byte{0}, filler)...)
+	result = append(result, byte(filler))
+
+	return result
+}
+
+func fillerSizeFor(dataSize, overhead int) int {
+	if matchesLegacyLayout(gcmContainerSize(dataSize, 0, overhead)) {
+		return 1
+	}
+
+	return 0
+}
+
+func gcmContainerSize(dataSize, filler, overhead int) int {
+	return formatVersionSize + gcmNonceSize + dataSize + filler + gcmFillerSizeLen + overhead
+}
+
+func matchesLegacyLayout(containerSize int) bool {
+	return containerSize >= legacyCBCMinimumDataBinarySize() &&
+		(containerSize-formatVersionSize-aes.BlockSize)%aes.BlockSize == 0
+}
+
+func unfill(sealed []byte) ([]byte, error) {
+	if len(sealed) < gcmFillerSizeLen {
+		return nil, errAuthenticationFailed
+	}
+
+	filler := int(sealed[len(sealed)-1])
+	if filler > gcmMaxFillerSize || len(sealed) < filler+gcmFillerSizeLen {
+		return nil, errAuthenticationFailed
+	}
+
+	return sealed[:len(sealed)-filler-gcmFillerSizeLen], nil
 }
 
 func legacyCBCMinimumDataBinarySize() int {

--- a/pkg/secret/aes_encoder_format_test.go
+++ b/pkg/secret/aes_encoder_format_test.go
@@ -1,0 +1,283 @@
+package secret
+
+import (
+	"bytes"
+	"crypto/aes"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestAesEncoderWritesAesGCMFormatVersion(t *testing.T) {
+	s, err := NewAesEncoder(AesSecretKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	encodedData, err := s.Encrypt([]byte("value"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if prefix := string(encodedData[:4]); prefix != "0200" {
+		t.Errorf("\n[EXPECTED]: %s\n[GOT]: %s", "0200", prefix)
+	}
+}
+
+// A version-2 ciphertext is shorter than the legacy minimum of 34 binary bytes, so a
+// minimum-length check left ahead of the version dispatch would reject valid data.
+func TestAesEncoderShortPlaintextRoundTrip(t *testing.T) {
+	s, err := NewAesEncoder(AesSecretKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, plainText := range []string{"", "a", "ab", "abc"} {
+		t.Run(fmt.Sprintf("%d bytes", len(plainText)), func(t *testing.T) {
+			encodedData, err := s.Encrypt([]byte(plainText))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if binarySize := hex.DecodedLen(len(encodedData)); binarySize >= legacyCBCMinimumDataBinarySize() {
+				t.Logf("ciphertext is %d binary bytes, legacy minimum is %d", binarySize, legacyCBCMinimumDataBinarySize())
+			}
+
+			result, err := s.Decrypt(encodedData)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if string(result) != plainText {
+				t.Errorf("\n[EXPECTED]: %q\n[GOT]: %q", plainText, string(result))
+			}
+		})
+	}
+}
+
+func TestAesEncoderRejectsEveryBitFlip(t *testing.T) {
+	s, err := NewAesEncoder(AesSecretKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	encodedData, err := s.Encrypt([]byte("postgres://user:hunter2@db:5432/app"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	original, err := hexToBinary(encodedData)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for bytePos := 0; bytePos < len(original); bytePos++ {
+		for bit := 0; bit < 8; bit++ {
+			tampered := make([]byte, len(original))
+			copy(tampered, original)
+			tampered[bytePos] ^= 1 << bit
+
+			tamperedHex := make([]byte, hex.EncodedLen(len(tampered)))
+			hex.Encode(tamperedHex, tampered)
+
+			// Flips inside the version prefix produce an unsupported-version error rather
+			// than an authentication failure, so any error is an acceptable rejection.
+			if _, err := s.Decrypt(tamperedHex); err == nil {
+				t.Fatalf("tampered ciphertext accepted: byte %d bit %d", bytePos, bit)
+			}
+		}
+	}
+}
+
+func TestAesEncoderRejectsWrongKey(t *testing.T) {
+	s, err := NewAesEncoder(AesSecretKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	other, err := NewAesEncoder([]byte("bc3458408a5687e60b9417adb84e4ad0"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	encodedData, err := s.Encrypt([]byte("value"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = other.Decrypt(encodedData)
+	if !errors.Is(err, errAuthenticationFailed) {
+		t.Errorf("expected an authentication failure, got: %v", err)
+	}
+
+	if IsExtractDataError(err) {
+		t.Error("an authentication failure must not be reported as a data error, so callers keep advising to check the encryption key")
+	}
+}
+
+func TestAesEncoderRejectsUnsupportedFormatVersion(t *testing.T) {
+	s, err := NewAesEncoder(AesSecretKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	encodedData, err := s.Encrypt([]byte("value"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	unsupported := append([]byte("0300"), encodedData[4:]...)
+
+	_, err = s.Decrypt(unsupported)
+	if !errors.Is(err, errUnsupportedFormatVersion) {
+		t.Fatalf("expected an unsupported version error, got: %v", err)
+	}
+
+	if !strings.Contains(err.Error(), "3") {
+		t.Errorf("expected the rejected version in the message, got: %v", err)
+	}
+
+	if !IsExtractDataError(err) {
+		t.Error("an unsupported format version is a data error")
+	}
+}
+
+func TestAesEncoderDecryptWithFormatReportsVersion(t *testing.T) {
+	s, err := NewAesEncoder(legacyFixtureKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, version, err := s.decryptWithFormat(legacyFixtureSecretFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if version != formatVersionLegacyCBC {
+		t.Errorf("\n[EXPECTED]: %d\n[GOT]: %d", formatVersionLegacyCBC, version)
+	}
+
+	encodedData, err := s.Encrypt([]byte("value"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, version, err = s.decryptWithFormat(encodedData)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if version != formatVersionAesGCM {
+		t.Errorf("\n[EXPECTED]: %d\n[GOT]: %d", formatVersionAesGCM, version)
+	}
+}
+
+func TestUnpad(t *testing.T) {
+	tests := []struct {
+		name        string
+		data        []byte
+		expected    string
+		expectError bool
+	}{
+		{
+			name:     "valid single byte of padding",
+			data:     append(bytes.Repeat([]byte("a"), aes.BlockSize-1), 0x01),
+			expected: strings.Repeat("a", aes.BlockSize-1),
+		},
+		{
+			name:     "valid full block of padding",
+			data:     bytes.Repeat([]byte{byte(aes.BlockSize)}, aes.BlockSize),
+			expected: "",
+		},
+		{
+			name:        "zero padding length",
+			data:        append(bytes.Repeat([]byte("a"), aes.BlockSize-1), 0x00),
+			expectError: true,
+		},
+		{
+			name:        "padding length above the block size",
+			data:        append(bytes.Repeat([]byte("a"), 2*aes.BlockSize-1), byte(aes.BlockSize+1)),
+			expectError: true,
+		},
+		{
+			name:        "padding length above the data length",
+			data:        append(bytes.Repeat([]byte("a"), 3), 0x08),
+			expectError: true,
+		},
+		{
+			name:        "inconsistent padding bytes",
+			data:        append(bytes.Repeat([]byte("a"), aes.BlockSize-4), 0x04, 0xff, 0x04, 0x04),
+			expectError: true,
+		},
+		{
+			name:        "empty data",
+			data:        []byte{},
+			expectError: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := unpad(test.data)
+
+			if test.expectError {
+				if !errors.Is(err, errUnpadFailed) {
+					t.Errorf("expected an unpad failure, got: %v", err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if string(result) != test.expected {
+				t.Errorf("\n[EXPECTED]: %q\n[GOT]: %q", test.expected, string(result))
+			}
+		})
+	}
+}
+
+func TestIsExtractDataError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "minimum data length",
+			err:      minimumDataLengthError(legacyCBCMinimumDataBinarySize()),
+			expected: true,
+		},
+		{
+			name:     "odd length hex string",
+			err:      fmt.Errorf("wrapped: %w", hex.ErrLength),
+			expected: true,
+		},
+		{
+			name:     "unsupported format version",
+			err:      fmt.Errorf("%w: %d", errUnsupportedFormatVersion, 3),
+			expected: true,
+		},
+		{
+			name:     "authentication failure",
+			err:      errAuthenticationFailed,
+			expected: false,
+		},
+		{
+			name:     "unpad failure",
+			err:      errUnpadFailed,
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := IsExtractDataError(test.err); got != test.expected {
+				t.Errorf("\n[EXPECTED]: %v\n[GOT]: %v", test.expected, got)
+			}
+		})
+	}
+}

--- a/pkg/secret/aes_encoder_format_test.go
+++ b/pkg/secret/aes_encoder_format_test.go
@@ -42,8 +42,8 @@ func TestAesEncoderShortPlaintextRoundTrip(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if binarySize := hex.DecodedLen(len(encodedData)); binarySize >= legacyCBCMinimumDataBinarySize() {
-				t.Errorf("ciphertext is %d binary bytes, at or above the legacy minimum of %d, so this no longer exercises a below-minimum ciphertext", binarySize, legacyCBCMinimumDataBinarySize())
+			if plainText == "" && hex.DecodedLen(len(encodedData)) >= legacyCBCMinimumDataBinarySize() {
+				t.Errorf("the smallest ciphertext is %d binary bytes, at or above the legacy minimum of %d, so this no longer exercises a below-minimum ciphertext", hex.DecodedLen(len(encodedData)), legacyCBCMinimumDataBinarySize())
 			}
 
 			result, err := s.Decrypt(encodedData)
@@ -92,26 +92,38 @@ func TestAesEncoderRejectsEveryBitFlip(t *testing.T) {
 	}
 }
 
-// A version-2 container whose plaintext length is 4 modulo 16 also satisfies the legacy
-// block layout, so a rewritten prefix reaches the CBC reader instead of being rejected on
-// shape alone. That reader cannot authenticate, so a small fraction of attempts is
-// accepted. What must hold is that such an attempt never yields the protected plaintext:
-// the attacker has no key, so anything accepted is unpredictable garbage.
-func TestAesEncoderDowngradeNeverRevealsPlaintext(t *testing.T) {
+// No version-2 container may ever sit on the legacy block grid, otherwise rewriting its
+// version prefix would hand it to the CBC reader, which cannot authenticate.
+func TestAesEncoderContainerNeverMatchesLegacyLayout(t *testing.T) {
 	s, err := NewAesEncoder(AesSecretKey)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	plainText := []byte("s3cr")
-	if len(plainText)%aes.BlockSize != 4 {
-		t.Fatalf("this test needs a plaintext length of 4 modulo 16 to reach the legacy reader, got %d", len(plainText))
+	for dataSize := 0; dataSize <= 200; dataSize++ {
+		encodedData, err := s.Encrypt(make([]byte, dataSize))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		containerSize := hex.DecodedLen(len(encodedData))
+		if matchesLegacyLayout(containerSize) {
+			t.Errorf("a %d-byte plaintext produced a %d-byte container, which the legacy reader would parse", dataSize, containerSize)
+		}
+	}
+}
+
+// Because no container sits on the legacy grid, rewriting the version prefix is now
+// rejected for every plaintext length rather than only for most of them.
+func TestAesEncoderRejectsVersionDowngrade(t *testing.T) {
+	s, err := NewAesEncoder(AesSecretKey)
+	if err != nil {
+		t.Fatal(err)
 	}
 
-	const trials = 2000
-	accepted := 0
+	for dataSize := 0; dataSize <= 200; dataSize++ {
+		plainText := bytes.Repeat([]byte("s"), dataSize)
 
-	for i := 0; i < trials; i++ {
 		encodedData, err := s.Encrypt(plainText)
 		if err != nil {
 			t.Fatal(err)
@@ -127,54 +139,9 @@ func TestAesEncoderDowngradeNeverRevealsPlaintext(t *testing.T) {
 		downgraded := make([]byte, hex.EncodedLen(len(raw)))
 		hex.Encode(downgraded, raw)
 
-		result, err := s.Decrypt(downgraded)
-		if err != nil {
-			continue
+		if _, err := s.Decrypt(downgraded); err == nil {
+			t.Fatalf("a version-downgraded ciphertext of a %d-byte plaintext was accepted", dataSize)
 		}
-
-		accepted++
-		if bytes.Equal(result, plainText) {
-			t.Fatal("a downgraded ciphertext revealed the protected plaintext")
-		}
-	}
-
-	// The expected rate is well under 1%; this only guards against the legacy reader
-	// turning permissive, not against the inherent gap itself.
-	if accepted*100 > trials*5 {
-		t.Errorf("legacy reader accepted %d of %d downgraded ciphertexts, far above the expected rate", accepted, trials)
-	}
-}
-
-// Rewriting the version prefix of a version-2 ciphertext to the legacy one routes it to
-// the CBC reader, which does not authenticate. For every plaintext length that does not
-// suit the legacy block layout the rewrite is rejected outright, deterministically.
-func TestAesEncoderRejectsVersionDowngrade(t *testing.T) {
-	s, err := NewAesEncoder(AesSecretKey)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	for _, plainText := range []string{"a", "ab", "abc", "abcde", "value", "a longer secret value"} {
-		t.Run(plainText, func(t *testing.T) {
-			encodedData, err := s.Encrypt([]byte(plainText))
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			raw, err := hexToBinary(encodedData)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			binary.LittleEndian.PutUint16(raw[:formatVersionSize], formatVersionLegacyCBC)
-
-			downgraded := make([]byte, hex.EncodedLen(len(raw)))
-			hex.Encode(downgraded, raw)
-
-			if _, err := s.Decrypt(downgraded); err == nil {
-				t.Error("a version-downgraded ciphertext was accepted")
-			}
-		})
 	}
 }
 

--- a/pkg/secret/aes_encoder_format_test.go
+++ b/pkg/secret/aes_encoder_format_test.go
@@ -3,6 +3,7 @@ package secret
 import (
 	"bytes"
 	"crypto/aes"
+	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -42,7 +43,7 @@ func TestAesEncoderShortPlaintextRoundTrip(t *testing.T) {
 			}
 
 			if binarySize := hex.DecodedLen(len(encodedData)); binarySize >= legacyCBCMinimumDataBinarySize() {
-				t.Logf("ciphertext is %d binary bytes, legacy minimum is %d", binarySize, legacyCBCMinimumDataBinarySize())
+				t.Errorf("ciphertext is %d binary bytes, at or above the legacy minimum of %d, so this no longer exercises a below-minimum ciphertext", binarySize, legacyCBCMinimumDataBinarySize())
 			}
 
 			result, err := s.Decrypt(encodedData)
@@ -88,6 +89,40 @@ func TestAesEncoderRejectsEveryBitFlip(t *testing.T) {
 				t.Fatalf("tampered ciphertext accepted: byte %d bit %d", bytePos, bit)
 			}
 		}
+	}
+}
+
+// Rewriting the version prefix of a version-2 ciphertext to the legacy one routes it to
+// the CBC reader, which does not authenticate. The length check rejects that outright
+// unless the blob happens to suit CBC, and the hardened unpad rejects almost all of the
+// rest. This pins the deterministic half; the residual is documented in doc.go.
+func TestAesEncoderRejectsVersionDowngrade(t *testing.T) {
+	s, err := NewAesEncoder(AesSecretKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, plainText := range []string{"a", "ab", "abc", "abcde", "value", "a longer secret value"} {
+		t.Run(plainText, func(t *testing.T) {
+			encodedData, err := s.Encrypt([]byte(plainText))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			raw, err := hexToBinary(encodedData)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			binary.LittleEndian.PutUint16(raw[:formatVersionSize], formatVersionLegacyCBC)
+
+			downgraded := make([]byte, hex.EncodedLen(len(raw)))
+			hex.Encode(downgraded, raw)
+
+			if _, err := s.Decrypt(downgraded); err == nil {
+				t.Error("a version-downgraded ciphertext was accepted")
+			}
+		})
 	}
 }
 

--- a/pkg/secret/aes_encoder_format_test.go
+++ b/pkg/secret/aes_encoder_format_test.go
@@ -92,29 +92,13 @@ func TestAesEncoderRejectsEveryBitFlip(t *testing.T) {
 	}
 }
 
-// No version-2 container may ever sit on the legacy block grid, otherwise rewriting its
-// version prefix would hand it to the CBC reader, which cannot authenticate.
-func TestAesEncoderContainerNeverMatchesLegacyLayout(t *testing.T) {
-	s, err := NewAesEncoder(AesSecretKey)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	for dataSize := 0; dataSize <= 200; dataSize++ {
-		encodedData, err := s.Encrypt(make([]byte, dataSize))
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		containerSize := hex.DecodedLen(len(encodedData))
-		if matchesLegacyLayout(containerSize) {
-			t.Errorf("a %d-byte plaintext produced a %d-byte container, which the legacy reader would parse", dataSize, containerSize)
-		}
-	}
-}
-
 // Because no container sits on the legacy grid, rewriting the version prefix is now
 // rejected for every plaintext length rather than only for most of them.
+//
+// The rejection must come from the size or block check, never from unpad: reaching unpad
+// would mean the blob was decrypted with an unauthenticated key stream first, and whether
+// that lands on valid padding is a matter of chance. Asserting only that some error came
+// back would accept that outcome roughly 995 times out of 1000 and hide the regression.
 func TestAesEncoderRejectsVersionDowngrade(t *testing.T) {
 	s, err := NewAesEncoder(AesSecretKey)
 	if err != nil {
@@ -139,8 +123,13 @@ func TestAesEncoderRejectsVersionDowngrade(t *testing.T) {
 		downgraded := make([]byte, hex.EncodedLen(len(raw)))
 		hex.Encode(downgraded, raw)
 
-		if _, err := s.Decrypt(downgraded); err == nil {
+		_, err = s.Decrypt(downgraded)
+		if err == nil {
 			t.Fatalf("a version-downgraded ciphertext of a %d-byte plaintext was accepted", dataSize)
+		}
+
+		if !errors.Is(err, errMinimumDataLength) && !errors.Is(err, errBlockSizeMultiple) {
+			t.Fatalf("a version-downgraded ciphertext of a %d-byte plaintext reached the legacy key stream instead of failing on shape: %v", dataSize, err)
 		}
 	}
 }

--- a/pkg/secret/aes_encoder_format_test.go
+++ b/pkg/secret/aes_encoder_format_test.go
@@ -92,10 +92,62 @@ func TestAesEncoderRejectsEveryBitFlip(t *testing.T) {
 	}
 }
 
+// A version-2 container whose plaintext length is 4 modulo 16 also satisfies the legacy
+// block layout, so a rewritten prefix reaches the CBC reader instead of being rejected on
+// shape alone. That reader cannot authenticate, so a small fraction of attempts is
+// accepted. What must hold is that such an attempt never yields the protected plaintext:
+// the attacker has no key, so anything accepted is unpredictable garbage.
+func TestAesEncoderDowngradeNeverRevealsPlaintext(t *testing.T) {
+	s, err := NewAesEncoder(AesSecretKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	plainText := []byte("s3cr")
+	if len(plainText)%aes.BlockSize != 4 {
+		t.Fatalf("this test needs a plaintext length of 4 modulo 16 to reach the legacy reader, got %d", len(plainText))
+	}
+
+	const trials = 2000
+	accepted := 0
+
+	for i := 0; i < trials; i++ {
+		encodedData, err := s.Encrypt(plainText)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		raw, err := hexToBinary(encodedData)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		binary.LittleEndian.PutUint16(raw[:formatVersionSize], formatVersionLegacyCBC)
+
+		downgraded := make([]byte, hex.EncodedLen(len(raw)))
+		hex.Encode(downgraded, raw)
+
+		result, err := s.Decrypt(downgraded)
+		if err != nil {
+			continue
+		}
+
+		accepted++
+		if bytes.Equal(result, plainText) {
+			t.Fatal("a downgraded ciphertext revealed the protected plaintext")
+		}
+	}
+
+	// The expected rate is well under 1%; this only guards against the legacy reader
+	// turning permissive, not against the inherent gap itself.
+	if accepted*100 > trials*5 {
+		t.Errorf("legacy reader accepted %d of %d downgraded ciphertexts, far above the expected rate", accepted, trials)
+	}
+}
+
 // Rewriting the version prefix of a version-2 ciphertext to the legacy one routes it to
-// the CBC reader, which does not authenticate. The length check rejects that outright
-// unless the blob happens to suit CBC, and the hardened unpad rejects almost all of the
-// rest. This pins the deterministic half; the residual is documented in doc.go.
+// the CBC reader, which does not authenticate. For every plaintext length that does not
+// suit the legacy block layout the rewrite is rejected outright, deterministically.
 func TestAesEncoderRejectsVersionDowngrade(t *testing.T) {
 	s, err := NewAesEncoder(AesSecretKey)
 	if err != nil {

--- a/pkg/secret/doc.go
+++ b/pkg/secret/doc.go
@@ -1,0 +1,56 @@
+// Package secret encrypts and decrypts werf secrets, either as whole blobs or as the
+// individual scalar values of a YAML document.
+//
+// # Encoded format
+//
+// An encoded value is the hex encoding of a binary payload that starts with a two-byte
+// little-endian format version:
+//
+//	version 16: [version][16-byte IV][AES-CBC ciphertext, PKCS#7 padded]
+//	version  2: [version][12-byte nonce][AES-GCM ciphertext and authentication tag]
+//
+// Version 16 is the legacy format. Those two bytes originally held the CBC IV size, were
+// always written as 16, and were never read back, which is why the field could be
+// repurposed as a version without changing the layout of existing data. It is read-only:
+// it still decrypts exactly as it always did, but it is never written any more.
+//
+// Version 2 is AES-GCM and is what Encrypt writes. Any other version is rejected with an
+// error rather than being decrypted as CBC.
+//
+// Both versions are read with the same secret key, so upgrading needs no new key and no
+// migration. The key format is unchanged: 16, 24 or 32 random bytes hex-encoded, as
+// produced by GenerateAesSecretKey.
+//
+// # Compatibility
+//
+// Reading is backward compatible, but writing is not forward compatible: a value written
+// in version 2 cannot be read by a werf or nelm release that predates version 2 support,
+// because those releases ignore the version field and decrypt everything as CBC. There is
+// no way to write the legacy format any more, so a repository whose secrets have been
+// re-encrypted needs every consumer, including CI jobs and saved deploy plans, to
+// understand version 2. Re-encrypting everything at once is what rotate-secret-key does.
+//
+// # Authentication
+//
+// The legacy CBC format has no integrity check, so a corrupted or deliberately modified
+// ciphertext could decrypt to garbage instead of failing, and a wrong key was often
+// accepted. AES-GCM authenticates, so tampering and wrong keys are reported as errors.
+// This protects newly written values only; existing values gain it once re-encrypted.
+//
+// # YAML scalars
+//
+// EncryptYamlData and DecryptYamlData encrypt each scalar leaf of a document in place.
+// From version 2 on, the YAML tag and the scalar style are stored inside the encrypted
+// payload, so a number stays a number and a block scalar keeps its style across a round
+// trip. Whole-blob Encrypt and Decrypt never add this framing.
+//
+// Values encrypted before version 2 did not store a tag, so that information does not
+// exist anywhere and cannot be recovered: they keep decrypting as strings. Re-encrypting
+// does not help, because by then the original type is already lost. The only way to give
+// such a value its intended type is to re-enter it, for example through
+// "werf helm secret values edit".
+//
+// A comment attached to an encrypted value is preserved, which means it stays cleartext in
+// the encrypted file, the same way mapping keys already do. Do not put secrets in
+// comments.
+package secret

--- a/pkg/secret/doc.go
+++ b/pkg/secret/doc.go
@@ -9,6 +9,14 @@
 //	version 16: [version][16-byte IV][AES-CBC ciphertext, PKCS#7 padded]
 //	version  2: [version][12-byte nonce][AES-GCM ciphertext and authentication tag]
 //
+// What version 2 seals is not the value on its own but:
+//
+//	[value][filler, 0 or 1 zero bytes][one byte holding the filler size]
+//
+// The filler is present only when the container would otherwise be the size of a legacy
+// container, and exists purely to keep the two formats apart; see Authentication below.
+// It is inside the sealed data, so it is authenticated along with the value.
+//
 // Version 16 is the legacy format. Those two bytes originally held the CBC IV size, were
 // always written as 16, and were never read back, which is why the field could be
 // repurposed as a version without changing the layout of existing data. It is read-only:
@@ -38,20 +46,21 @@
 // This protects newly written values only; existing values gain it once re-encrypted.
 //
 // The version prefix of a version 2 value is authenticated, so it cannot be altered
-// within that format. It cannot be bound any tighter than that: rewriting the prefix to
-// 16 sends the value to the legacy CBC reader, which by definition does not authenticate.
-// Such a value is still rejected unless its length happens to suit the legacy block
-// layout and the decrypted tail happens to form valid padding, and what comes out is
-// unpredictable garbage rather than anything the attacker chooses, since they do not hold
-// the key.
+// within that format. On its own that would not be enough, because rewriting the prefix
+// to 16 hands the value to the legacy CBC reader, which by definition does not
+// authenticate and would never consult it. That is what the filler is for: a version 2
+// container is never the size of a legacy one, so a rewritten prefix always fails the
+// legacy size and block checks. Such a value is rejected outright, for every possible
+// value length, rather than merely most of the time.
 //
-// This grants an attacker nothing they did not already have. Anyone able to rewrite those
-// two bytes can just as easily replace the whole value with a legacy blob of their own,
-// which this package must keep reading, and that succeeds at the same small rate. The
-// exposure is not the rewrite but the fact that an unauthenticated format stays readable,
-// and that is the price of not breaking existing data. Re-encrypting with
-// rotate-secret-key does not change it either, because the legacy reader has to stay for
-// as long as any legacy value might exist anywhere.
+// What remains is that the legacy format itself stays readable. Anyone able to rewrite
+// those two bytes can instead replace the whole value with a legacy blob of their own,
+// and that has a small chance of being accepted, returning unpredictable garbage rather
+// than anything they choose, since they do not hold the key. So the exposure is the
+// readable unauthenticated format, not any particular way of reaching it, and that is the
+// price of not breaking existing data. Re-encrypting with rotate-secret-key does not
+// change it either, because the legacy reader has to stay for as long as any legacy value
+// might exist anywhere.
 //
 // # YAML scalars
 //

--- a/pkg/secret/doc.go
+++ b/pkg/secret/doc.go
@@ -37,6 +37,16 @@
 // accepted. AES-GCM authenticates, so tampering and wrong keys are reported as errors.
 // This protects newly written values only; existing values gain it once re-encrypted.
 //
+// The version prefix of a version 2 value is authenticated, so it cannot be altered
+// within that format. It cannot be bound any tighter than that: rewriting the prefix to
+// 16 sends the value to the legacy CBC reader, which by definition does not authenticate.
+// Such a value is still rejected unless its length happens to suit CBC and the decrypted
+// tail happens to form valid padding, and the result is unpredictable garbage rather than
+// anything the attacker chooses, since they do not hold the key. Removing this last gap
+// means dropping the ability to read legacy values, which is exactly what must not break.
+// Re-encrypting a repository with rotate-secret-key does not close it either, because the
+// legacy reader has to stay for as long as any legacy value might exist.
+//
 // # YAML scalars
 //
 // EncryptYamlData and DecryptYamlData encrypt each scalar leaf of a document in place.

--- a/pkg/secret/doc.go
+++ b/pkg/secret/doc.go
@@ -40,12 +40,18 @@
 // The version prefix of a version 2 value is authenticated, so it cannot be altered
 // within that format. It cannot be bound any tighter than that: rewriting the prefix to
 // 16 sends the value to the legacy CBC reader, which by definition does not authenticate.
-// Such a value is still rejected unless its length happens to suit CBC and the decrypted
-// tail happens to form valid padding, and the result is unpredictable garbage rather than
-// anything the attacker chooses, since they do not hold the key. Removing this last gap
-// means dropping the ability to read legacy values, which is exactly what must not break.
-// Re-encrypting a repository with rotate-secret-key does not close it either, because the
-// legacy reader has to stay for as long as any legacy value might exist.
+// Such a value is still rejected unless its length happens to suit the legacy block
+// layout and the decrypted tail happens to form valid padding, and what comes out is
+// unpredictable garbage rather than anything the attacker chooses, since they do not hold
+// the key.
+//
+// This grants an attacker nothing they did not already have. Anyone able to rewrite those
+// two bytes can just as easily replace the whole value with a legacy blob of their own,
+// which this package must keep reading, and that succeeds at the same small rate. The
+// exposure is not the rewrite but the fact that an unauthenticated format stays readable,
+// and that is the price of not breaking existing data. Re-encrypting with
+// rotate-secret-key does not change it either, because the legacy reader has to stay for
+// as long as any legacy value might exist anywhere.
 //
 // # YAML scalars
 //

--- a/pkg/secret/encoder.go
+++ b/pkg/secret/encoder.go
@@ -4,3 +4,10 @@ type Encoder interface {
 	Encrypt(data []byte) ([]byte, error)
 	Decrypt(encodedData []byte) ([]byte, error)
 }
+
+// formatAwareDecrypter is implemented by encoders whose ciphertext carries a format
+// version. YamlEncoder only stores and restores YAML scalar metadata when its Encoder
+// implements this, so that any other Encoder keeps producing and consuming plain values.
+type formatAwareDecrypter interface {
+	decryptWithFormat(encodedData []byte) ([]byte, uint16, error)
+}

--- a/pkg/secret/legacy_compat_test.go
+++ b/pkg/secret/legacy_compat_test.go
@@ -1,0 +1,76 @@
+package secret
+
+import (
+	"testing"
+)
+
+// Ciphertexts and key below are copied verbatim from werf's committed e2e fixtures
+// (test/e2e/converge/_fixtures/complex/state0). They are the backward-compatibility
+// contract for the legacy AES-CBC format and must never be regenerated.
+var (
+	legacyFixtureKey = []byte("bc3458408a5687e60b9417adb84e4ad0")
+
+	legacyFixtureSecretValues = "added_via_secret_values: 10007b717b44ec49b722c5d517cf6259bd20c93ea5ef2dcfc3934bccee59613d0ac07f5f39835d30f3736fc5d3edc10335bb\n" +
+		"overridden_via_secret_values: 1000ad8725d33000e7bf81a5b65851003b9ca35e999b617ccff1fe402c7a941382f4fc5c9257de633a42427958b5fb43b2e3\n"
+
+	legacyFixtureSecretValuesExtra = "added_via_secret_values_extra: 1000dc58aec55b8ce919d24fd1a9c5435f983d9a39f1fba0971d2452ae30d03788dffd4ff2d179b426e62badec66c12e2f7d\n" +
+		"overridden_via_secret_values_extra: 1000b52f32b4f9a78fb8b53e2a4d4211408b0de9c9bc83a8cda7a6be77e288f307bf90d016b476960f3c99ab51be48b318fcb4f404a4559bec045631902ec5f49728\n"
+
+	legacyFixtureSecretFile = []byte("100052fb0fa1cc8ef1cb123be089cdb853cc153772691b8fb743d612a7b64d65614d4d8745250752564941227eb8d7161523")
+)
+
+func TestLegacyFixtureYamlDataDecrypts(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     string
+		expected string
+	}{
+		{
+			name:     "secret-values.yaml",
+			data:     legacyFixtureSecretValues,
+			expected: "added_via_secret_values: added_via_secret_values\noverridden_via_secret_values: overridden_via_secret_values\n",
+		},
+		{
+			name:     "secret-values-extra.yaml",
+			data:     legacyFixtureSecretValuesExtra,
+			expected: "added_via_secret_values_extra: added_via_secret_values_extra\noverridden_via_secret_values_extra: overridden_via_secret_values_extra\n",
+		},
+	}
+
+	encoder, err := NewAesEncoder(legacyFixtureKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	yamlEncoder := NewYamlEncoder(encoder)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := yamlEncoder.DecryptYamlData([]byte(test.data))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if string(result) != test.expected {
+				t.Errorf("\n[EXPECTED]: %q\n[GOT]: %q", test.expected, string(result))
+			}
+		})
+	}
+}
+
+func TestLegacyFixtureSecretFileDecrypts(t *testing.T) {
+	encoder, err := NewAesEncoder(legacyFixtureKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := encoder.Decrypt(legacyFixtureSecretFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "secretConfigContent\n"
+	if string(result) != expected {
+		t.Errorf("\n[EXPECTED]: %q\n[GOT]: %q", expected, string(result))
+	}
+}

--- a/pkg/secret/yaml_encoder.go
+++ b/pkg/secret/yaml_encoder.go
@@ -3,6 +3,7 @@ package secret
 import (
 	"bytes"
 	"fmt"
+	"strconv"
 
 	yaml_v3 "gopkg.in/yaml.v3"
 )
@@ -13,6 +14,7 @@ type YamlEncoder struct {
 
 	generateFunc func([]byte) ([]byte, error)
 	extractFunc  func([]byte) ([]byte, error)
+	formatAware  formatAwareDecrypter
 }
 
 func NewYamlEncoder(encoder Encoder) *YamlEncoder {
@@ -21,6 +23,10 @@ func NewYamlEncoder(encoder Encoder) *YamlEncoder {
 	if encoder != nil {
 		yamlEncoder.generateFunc = encoder.Encrypt
 		yamlEncoder.extractFunc = encoder.Decrypt
+
+		if formatAware, ok := encoder.(formatAwareDecrypter); ok {
+			yamlEncoder.formatAware = formatAware
+		}
 	} else {
 		yamlEncoder.generateFunc = doNothing
 		yamlEncoder.extractFunc = doNothing
@@ -39,7 +45,7 @@ func (s *YamlEncoder) Encrypt(data []byte) ([]byte, error) {
 }
 
 func (s *YamlEncoder) EncryptYamlData(data []byte) ([]byte, error) {
-	resultData, err := doYamlDataV2(s.generateFunc, data, encryptYamlMode)
+	resultData, err := doYamlDataV2(s.generateFunc, s.formatAware, data, encryptYamlMode)
 	if err != nil {
 		return nil, fmt.Errorf("encryption failed: check encryption key and data: %w", err)
 	}
@@ -61,7 +67,7 @@ func (s *YamlEncoder) Decrypt(data []byte) ([]byte, error) {
 }
 
 func (s *YamlEncoder) DecryptYamlData(data []byte) ([]byte, error) {
-	resultData, err := doYamlDataV2(s.extractFunc, data, decryptYamlMode)
+	resultData, err := doYamlDataV2(s.extractFunc, s.formatAware, data, decryptYamlMode)
 	if err != nil {
 		if IsExtractDataError(err) {
 			return nil, fmt.Errorf("decryption failed: check data `%s`: %w", string(data), err)
@@ -73,14 +79,14 @@ func (s *YamlEncoder) DecryptYamlData(data []byte) ([]byte, error) {
 	return resultData, nil
 }
 
-func doYamlDataV2(doFunc func([]byte) ([]byte, error), data []byte, mode yamlProcessorMode) ([]byte, error) {
+func doYamlDataV2(doFunc func([]byte) ([]byte, error), formatAware formatAwareDecrypter, data []byte, mode yamlProcessorMode) ([]byte, error) {
 	var config yaml_v3.Node
 
 	if err := yaml_v3.Unmarshal(data, &config); err != nil {
 		return nil, fmt.Errorf("unable to unmarshal config data: %w", err)
 	}
 
-	resultConfig, err := doYamlValueSecretV2(doFunc, deepCopyNode(&config), mode)
+	resultConfig, err := doYamlValueSecretV2(doFunc, formatAware, deepCopyNode(&config), mode)
 	if err != nil {
 		return nil, fmt.Errorf("unable to process config secrets: %w", err)
 	}
@@ -132,11 +138,11 @@ func deepCopyNode(node *yaml_v3.Node) *yaml_v3.Node {
 	return copyNode
 }
 
-func doYamlValueSecretV2(doFunc func([]byte) ([]byte, error), node *yaml_v3.Node, mode yamlProcessorMode) (*yaml_v3.Node, error) {
+func doYamlValueSecretV2(doFunc func([]byte) ([]byte, error), formatAware formatAwareDecrypter, node *yaml_v3.Node, mode yamlProcessorMode) (*yaml_v3.Node, error) {
 	switch node.Kind {
 	case yaml_v3.DocumentNode:
 		for pos := 0; pos < len(node.Content); pos += 1 {
-			newValueNode, err := doYamlValueSecretV2(doFunc, deepCopyNode(node.Content[pos]), mode)
+			newValueNode, err := doYamlValueSecretV2(doFunc, formatAware, deepCopyNode(node.Content[pos]), mode)
 			if err != nil {
 				return nil, fmt.Errorf("unable to process document key %d: %w", pos, err)
 			}
@@ -147,7 +153,7 @@ func doYamlValueSecretV2(doFunc func([]byte) ([]byte, error), node *yaml_v3.Node
 		for pos := 0; pos < len(node.Content); pos += 2 {
 			keyNode := node.Content[pos]
 			valueNode := node.Content[pos+1]
-			newValueNode, err := doYamlValueSecretV2(doFunc, deepCopyNode(valueNode), mode)
+			newValueNode, err := doYamlValueSecretV2(doFunc, formatAware, deepCopyNode(valueNode), mode)
 			if err != nil {
 				return nil, fmt.Errorf("unable to process map key %q value=%v: %w", keyNode.Value, valueNode.Value, err)
 			}
@@ -156,7 +162,7 @@ func doYamlValueSecretV2(doFunc func([]byte) ([]byte, error), node *yaml_v3.Node
 
 	case yaml_v3.SequenceNode:
 		for pos := 0; pos < len(node.Content); pos += 1 {
-			newValueNode, err := doYamlValueSecretV2(doFunc, deepCopyNode(node.Content[pos]), mode)
+			newValueNode, err := doYamlValueSecretV2(doFunc, formatAware, deepCopyNode(node.Content[pos]), mode)
 			if err != nil {
 				return nil, fmt.Errorf("unable to process array key %d: %w", pos, err)
 			}
@@ -164,7 +170,7 @@ func doYamlValueSecretV2(doFunc func([]byte) ([]byte, error), node *yaml_v3.Node
 		}
 
 	case yaml_v3.AliasNode:
-		newAliasNode, err := doYamlValueSecretV2(doFunc, deepCopyNode(node.Alias), mode)
+		newAliasNode, err := doYamlValueSecretV2(doFunc, formatAware, deepCopyNode(node.Alias), mode)
 		if err != nil {
 			return nil, fmt.Errorf("unable to process an alias node %q: %w", node.Value, err)
 		}
@@ -184,46 +190,130 @@ func doYamlValueSecretV2(doFunc func([]byte) ([]byte, error), node *yaml_v3.Node
 					return nil, fmt.Errorf("unable to decode string value %q: %w", node.Value, err)
 				}
 
+				if formatAware != nil {
+					return node, decryptScalarWithMetadata(formatAware, node, value)
+				}
+
 				newValue, err := doFunc([]byte(value))
 				if err != nil {
 					return nil, err
 				}
 
-				if err := node.Encode(string(newValue)); err != nil {
-					return nil, fmt.Errorf("unable to encode string value %q: %w", string(newValue), err)
+				if err := encodeScalarPreservingComments(node, string(newValue)); err != nil {
+					return nil, err
 				}
 			default:
 				return nil, fmt.Errorf("unable to decode non string value %q: expected encoded value as hex string", node.Value)
 			}
 
 		case encryptYamlMode:
-			// FIXME: support all types, by node.ShortTag()
-
 			switch node.ShortTag() {
 			case "!!null":
 			// ignore
 
 			default:
-				var value interface{}
-
-				if err := node.Decode(&value); err != nil {
-					return nil, fmt.Errorf("unable to decode string value %q: %w", node.Value, err)
-				}
-
-				// FIXME: this is compatibility mode with previous werf version
-				newValue, err := doFunc([]byte(fmt.Sprintf("%v", value)))
+				plainText, err := scalarPlainText(formatAware, node)
 				if err != nil {
 					return nil, err
 				}
 
-				if err := node.Encode(string(newValue)); err != nil {
-					return nil, fmt.Errorf("unable to encode string value %q: %w", string(newValue), err)
+				newValue, err := doFunc(plainText)
+				if err != nil {
+					return nil, err
+				}
+
+				// The ciphertext is always emitted as an ordinary string scalar. Carrying the
+				// original tag over would make older readers reject the node, and carrying a
+				// folded style over would let the emitter fold line breaks into the hex.
+				if err := encodeScalarPreservingComments(node, string(newValue)); err != nil {
+					return nil, err
 				}
 			}
 		}
 	}
 
 	return node, nil
+}
+
+func scalarPlainText(formatAware formatAwareDecrypter, node *yaml_v3.Node) ([]byte, error) {
+	if formatAware != nil {
+		return frameScalar(node.ShortTag(), node.Style, node.Value), nil
+	}
+
+	var value interface{}
+	if err := node.Decode(&value); err != nil {
+		return nil, fmt.Errorf("unable to decode string value %q: %w", node.Value, err)
+	}
+
+	return []byte(fmt.Sprintf("%v", value)), nil
+}
+
+func decryptScalarWithMetadata(formatAware formatAwareDecrypter, node *yaml_v3.Node, value string) error {
+	plainText, version, err := formatAware.decryptWithFormat([]byte(value))
+	if err != nil {
+		return err
+	}
+
+	if version != formatVersionAesGCM {
+		return encodeScalarPreservingComments(node, string(plainText))
+	}
+
+	tag, style, originalValue, err := unframeScalar(plainText)
+	if err != nil {
+		return err
+	}
+
+	node.Kind = yaml_v3.ScalarNode
+	node.Tag = tag
+	node.Style = style
+	node.Value = originalValue
+	node.Content = nil
+	node.Alias = nil
+
+	return nil
+}
+
+func encodeScalarPreservingComments(node *yaml_v3.Node, value string) error {
+	headComment, lineComment, footComment := node.HeadComment, node.LineComment, node.FootComment
+
+	if err := node.Encode(value); err != nil {
+		return fmt.Errorf("unable to encode string value %q: %w", value, err)
+	}
+
+	node.HeadComment, node.LineComment, node.FootComment = headComment, lineComment, footComment
+
+	return nil
+}
+
+const scalarFrameSeparator = 0
+
+// frameScalar stores the YAML metadata of a scalar next to its raw value so that the tag
+// and style survive a round trip. The value comes last and is treated as opaque bytes, so
+// it may contain separators, newlines or anything else.
+func frameScalar(shortTag string, style yaml_v3.Style, value string) []byte {
+	var payload bytes.Buffer
+
+	payload.WriteString(shortTag)
+	payload.WriteByte(scalarFrameSeparator)
+	payload.WriteString(strconv.Itoa(int(style)))
+	payload.WriteByte(scalarFrameSeparator)
+	payload.WriteString(value)
+
+	return payload.Bytes()
+}
+
+func unframeScalar(payload []byte) (string, yaml_v3.Style, string, error) {
+	parts := bytes.SplitN(payload, []byte{scalarFrameSeparator}, 3)
+	if len(parts) != 3 {
+		return "", 0, "", fmt.Errorf("malformed encrypted scalar payload: expected tag, style and value")
+	}
+
+	style, err := strconv.Atoi(string(parts[1]))
+	if err != nil {
+		return "", 0, "", fmt.Errorf("unable to parse scalar style %q: %w", string(parts[1]), err)
+	}
+
+	return string(parts[0]), yaml_v3.Style(style), string(parts[2]), nil
 }
 
 func doNothing(data []byte) ([]byte, error) { return data, nil }

--- a/pkg/secret/yaml_encoder_fidelity_test.go
+++ b/pkg/secret/yaml_encoder_fidelity_test.go
@@ -118,6 +118,40 @@ var _ = Describe("YamlEncoder scalar fidelity", func() {
 		Expect(root["items"]).To(Equal([]interface{}{1, "two", 3.5}))
 	})
 
+	It("leaves values untouched and unframed without an encoder", func() {
+		data := "v: 0200abcdef\n"
+
+		decrypted, err := NewYamlEncoder(nil).DecryptYamlData([]byte(data))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(decrypted)).To(Equal(data))
+	})
+
+	It("does not frame a whole blob, so a secret file round trips unchanged", func() {
+		aesEncoder, err := NewAesEncoder(AesSecretKey)
+		Expect(err).NotTo(HaveOccurred())
+
+		content := "line1\nline2\n"
+
+		encoded, err := aesEncoder.Encrypt([]byte(content))
+		Expect(err).NotTo(HaveOccurred())
+
+		decoded, err := aesEncoder.Decrypt(encoded)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(decoded)).To(Equal(content))
+		Expect(string(decoded)).NotTo(ContainSubstring(string([]byte{scalarFrameSeparator})))
+	})
+
+	It("reports an unframed payload found in a YAML value instead of corrupting it", func() {
+		aesEncoder, err := NewAesEncoder(AesSecretKey)
+		Expect(err).NotTo(HaveOccurred())
+
+		blob, err := aesEncoder.Encrypt([]byte("no framing here"))
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = NewYamlEncoder(aesEncoder).DecryptYamlData([]byte("v: " + string(blob) + "\n"))
+		Expect(err).To(MatchError(ContainSubstring("malformed encrypted scalar payload")))
+	})
+
 	It("still decrypts a legacy ciphertext as a plain string", func() {
 		legacyEncoder, err := NewAesEncoder(legacyFixtureKey)
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/secret/yaml_encoder_fidelity_test.go
+++ b/pkg/secret/yaml_encoder_fidelity_test.go
@@ -1,0 +1,130 @@
+package secret
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	yaml_v3 "gopkg.in/yaml.v3"
+)
+
+func scalarOf(data string) *yaml_v3.Node {
+	var document yaml_v3.Node
+	Expect(yaml_v3.Unmarshal([]byte(data), &document)).To(Succeed())
+	return document.Content[0].Content[1]
+}
+
+var _ = Describe("YamlEncoder scalar fidelity", func() {
+	var encoder *YamlEncoder
+
+	BeforeEach(func() {
+		aesEncoder, err := NewAesEncoder(AesSecretKey)
+		Expect(err).NotTo(HaveOccurred())
+		encoder = NewYamlEncoder(aesEncoder)
+	})
+
+	DescribeTable("tag, style and value of a scalar survive an encrypt then decrypt round trip",
+		func(data string) {
+			encrypted, err := encoder.EncryptYamlData([]byte(data))
+			Expect(err).NotTo(HaveOccurred())
+
+			decrypted, err := encoder.DecryptYamlData(encrypted)
+			Expect(err).NotTo(HaveOccurred())
+
+			original := scalarOf(data)
+			restored := scalarOf(string(decrypted))
+
+			Expect(restored.Value).To(Equal(original.Value), "value")
+			Expect(restored.ShortTag()).To(Equal(original.ShortTag()), "tag")
+			Expect(restored.Style).To(Equal(original.Style), "style")
+		},
+		Entry("integer", "v: 123\n"),
+		Entry("negative integer", "v: -7\n"),
+		Entry("boolean", "v: true\n"),
+		Entry("float", "v: 64.5\n"),
+		Entry("timestamp", "v: 2022-07-15\n"),
+		Entry("binary", "v: !!binary R0lGODlhDAAMAIQAAP//9/X17unp5WZmZgAAAOfn515eXg==\n"),
+		Entry("plain string", "v: hello\n"),
+		Entry("numeric string", "v: \"123\"\n"),
+		Entry("boolean-like string", "v: \"true\"\n"),
+		Entry("folded block string", "v: >-\n  hello\n  world\n"),
+		Entry("literal block string", "v: |\n  line1\n  line2\n"),
+		Entry("empty string", "v: \"\"\n"),
+		Entry("only newlines", "v: \"\\n\\n\"\n"),
+		Entry("embedded separator byte", "v: \"a\\0b\\0c\"\n"),
+		Entry("tabs and carriage returns", "v: \"a\\tb\\r\\nc\"\n"),
+		Entry("leading whitespace", "v: \"  indented\"\n"),
+		Entry("unicode with combining marks and astral characters", "v: \"паро́ль→\\U0001F510\"\n"),
+		Entry("colon and hash", "v: \"a: b # c\"\n"),
+		Entry("long value with double spaces", "v: \"word word word word word word word word word word word word word word word word x  y\"\n"),
+	)
+
+	It("keeps a null value untouched", func() {
+		data := "v:\n"
+
+		encrypted, err := encoder.EncryptYamlData([]byte(data))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(encrypted)).To(Equal(data))
+
+		decrypted, err := encoder.DecryptYamlData(encrypted)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(decrypted)).To(Equal(data))
+	})
+
+	It("emits the ciphertext as an ordinary string scalar so that older readers accept it", func() {
+		encrypted, err := encoder.EncryptYamlData([]byte("v: 123\n"))
+		Expect(err).NotTo(HaveOccurred())
+
+		cipherScalar := scalarOf(string(encrypted))
+		Expect(cipherScalar.ShortTag()).To(Equal("!!str"))
+		Expect(cipherScalar.Style).To(Equal(yaml_v3.Style(0)))
+		Expect(cipherScalar.Value).To(HavePrefix("0200"))
+	})
+
+	It("preserves comments attached to a value and to a key", func() {
+		data := "# head comment on key\nv: 123 # line comment on value\n"
+
+		encrypted, err := encoder.EncryptYamlData([]byte(data))
+		Expect(err).NotTo(HaveOccurred())
+
+		decrypted, err := encoder.DecryptYamlData(encrypted)
+		Expect(err).NotTo(HaveOccurred())
+
+		var document yaml_v3.Node
+		Expect(yaml_v3.Unmarshal(decrypted, &document)).To(Succeed())
+
+		keyNode := document.Content[0].Content[0]
+		valueNode := document.Content[0].Content[1]
+
+		Expect(keyNode.HeadComment).To(Equal("# head comment on key"))
+		Expect(valueNode.LineComment).To(Equal("# line comment on value"))
+		Expect(valueNode.Value).To(Equal("123"))
+		Expect(valueNode.ShortTag()).To(Equal("!!int"))
+	})
+
+	It("restores types through nested mappings, sequences and anchors", func() {
+		data := "root: &anchor\n  count: 3\n  enabled: false\n  items:\n    - 1\n    - two\n    - 3.5\nalias: *anchor\n"
+
+		encrypted, err := encoder.EncryptYamlData([]byte(data))
+		Expect(err).NotTo(HaveOccurred())
+
+		decrypted, err := encoder.DecryptYamlData(encrypted)
+		Expect(err).NotTo(HaveOccurred())
+
+		var restored map[string]interface{}
+		Expect(yaml_v3.Unmarshal(decrypted, &restored)).To(Succeed())
+
+		root := restored["root"].(map[string]interface{})
+		Expect(root["count"]).To(Equal(3))
+		Expect(root["enabled"]).To(Equal(false))
+		Expect(root["items"]).To(Equal([]interface{}{1, "two", 3.5}))
+	})
+
+	It("still decrypts a legacy ciphertext as a plain string", func() {
+		legacyEncoder, err := NewAesEncoder(legacyFixtureKey)
+		Expect(err).NotTo(HaveOccurred())
+
+		decrypted, err := NewYamlEncoder(legacyEncoder).DecryptYamlData([]byte(legacyFixtureSecretValues))
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(string(decrypted)).To(Equal("added_via_secret_values: added_via_secret_values\noverridden_via_secret_values: overridden_via_secret_values\n"))
+	})
+})

--- a/pkg/secret/yaml_encoder_test.go
+++ b/pkg/secret/yaml_encoder_test.go
@@ -103,8 +103,10 @@ image:
 `),
 	)
 
-	// TODO: support restoring of original type during decode
-	It("should encode integer, bool, float, timestamp and binary as string, then convert to string during decode", func() {
+	// An Encoder without the format-aware capability, such as EncoderMock here, keeps the
+	// original behaviour of stringifying every scalar. AesEncoder stores the tag and the
+	// style inside the payload instead, which is covered by "YamlEncoder scalar fidelity".
+	It("should encode integer, bool, float, timestamp and binary as string, then convert to string during decode, for an encoder without format support", func() {
 		originalData := `
 mystring: value
 mybool: !!bool true

--- a/pkg/secret/yaml_helpers.go
+++ b/pkg/secret/yaml_helpers.go
@@ -101,7 +101,11 @@ func MergeEncodedYamlNode(oldConfig, newConfig, oldEncodedConfig, newEncodedConf
 		newEncodedConfig.Alias = newAliasNode
 
 	case yaml_v3.ScalarNode:
-		if oldConfig.Value == newConfig.Value {
+		// The tag and the style are part of what gets encrypted, so a change to either of
+		// them has to produce new ciphertext even when the raw value is untouched.
+		if oldConfig.Value == newConfig.Value &&
+			oldConfig.ShortTag() == newConfig.ShortTag() &&
+			oldConfig.Style == newConfig.Style {
 			return oldEncodedConfig, nil
 		}
 		return newEncodedConfig, nil

--- a/pkg/secret/yaml_helpers_test.go
+++ b/pkg/secret/yaml_helpers_test.go
@@ -480,3 +480,24 @@ hosts:
 		}),
 	)
 })
+
+var _ = Describe("MergeEncodedYaml scalar metadata", func() {
+	DescribeTable("reuse the old encoded value only when the value, the tag and the style are all unchanged",
+		func(oldData, newData, expectedResult string) {
+			const oldEncodedData = "v: OLD\n"
+			const newEncodedData = "v: NEW\n"
+
+			res, err := MergeEncodedYaml([]byte(oldData), []byte(newData), []byte(oldEncodedData), []byte(newEncodedData))
+			Expect(err).To(Succeed())
+			Expect(string(res)).To(Equal(expectedResult))
+		},
+		Entry("nothing changed", "v: 123\n", "v: 123\n", "v: OLD\n"),
+		Entry("value changed", "v: 123\n", "v: 124\n", "v: NEW\n"),
+		Entry("type changed from string to integer", "v: \"123\"\n", "v: 123\n", "v: NEW\n"),
+		Entry("type changed from integer to string", "v: 123\n", "v: \"123\"\n", "v: NEW\n"),
+		Entry("style changed from folded block to plain", "v: >-\n  hi\n", "v: hi\n", "v: NEW\n"),
+		Entry("style changed from plain to folded block", "v: hi\n", "v: >-\n  hi\n", "v: NEW\n"),
+		Entry("style changed from plain to double quoted", "v: hi\n", "v: \"hi\"\n", "v: NEW\n"),
+		Entry("explicit and implicit string tags are equal", "v: hi\n", "v: hi\n", "v: OLD\n"),
+	)
+})


### PR DESCRIPTION
## Summary

Fixes werf/nelm#677: encryption is unauthenticated, YAML scalar types are lost on encryption, and block styles and value comments are discarded. Existing ciphertext keeps decrypting byte-for-byte.

## Why

AES-CBC with no MAC has no integrity check. Measured against the current code: 50 of 64 single-bit flips in a ciphertext are silently accepted and return garbled plaintext, and a wrong key is accepted 19.1% of the time — `unpad` accepts any final byte from `0` to `len(data)` instead of `1..BlockSize`.

Separately, every scalar was encrypted as `fmt.Sprintf("%v", value)`, so `foo: 123` decrypted to `foo: "123"`, and `node.Encode` overwrote the node wholesale, dropping `>-`/`|` styles and value comments.

## Key changes

- **Format version.** The 2-byte LE prefix — always written as `16`, never read back — becomes a discriminator: `16` legacy AES-CBC (read-only), `2` AES-GCM (written by default), anything else an explicit error. The minimum-length check moves inside the branches, since a version-2 container is shorter than a legacy one.
- **AES-GCM**, fresh `crypto/rand` nonce per value. Key handling is untouched (16/24/32 bytes), so `generate-secret-key`, `WERF_SECRET_KEY` and `.werf_secret_key` are unaffected and no key is regenerated.
- A version-2 container never shares a size with a legacy one, so rewriting its prefix to `16` cannot route the value to the unauthenticated reader. What buys that: the sealed data carries 0–1 filler bytes and a trailing byte recording how many, added only for the lengths that would otherwise land on the legacy block grid. The filler sits inside the AEAD, so it is authenticated with the value.
- `unpad` hardened (rejects `0` and `> BlockSize`, verifies every byte) on the legacy read path only. `IsExtractDataError` keeps its signature and now classifies with `errors.Is` instead of message prefixes.
- **YAML fidelity.** Tag and style travel inside the ciphertext, so the encrypted file does not advertise the type of each secret; comments are restored around `node.Encode`. `MergeEncodedYamlNode` compares `Value` + `ShortTag()` + `Style`, otherwise `edit` keeps stale ciphertext when only a type or style changes.
- `doc.go` documents the format contract and its limits.

Public API is unchanged, so consumers need only a version bump. `pkg/secrets_manager` is untouched.

## Review focus / risks

- **Forward compatibility breaks.** Version-2 data cannot be read by released werf/nelm: they ignore the version field and CBC-decrypt whatever they find. There is no opt-out and no downgrade path, so the release note naming a minimum reader version is the entire mitigation. This bites plan artifacts too, which re-encrypt secret values even when nobody edited `secret-values.yaml`.
- **Existing values do not regain their types** — the tag was never stored, so the information does not exist. A value is fixed only by re-entering it.
- Value comments are now cleartext in the encrypted file; previously they were destroyed.
- A whole-blob ciphertext pasted into a YAML value now errors instead of decrypting.
- `pkg/secret/legacy_compat_test.go` pins real fixture ciphertexts from werf's e2e corpus and must never be regenerated — it is the backward-compatibility contract.
- The downgrade property is easy to test vacuously. Asserting merely that *some* error came back let the test pass with the filler removed in 0 of 20 runs, because a container that reaches the legacy key stream is rejected only when the decrypted tail happens not to form valid padding. It now requires the rejection to come from the size or block check, before any key stream runs; the same mutation fails 20 of 20.

## After merge

- [ ] **Release note — this is the only mitigation, do not skip.** Name the minimum werf/nelm version that can read the new format. Version-2 data is unreadable by every earlier release, there is no opt-out and no downgrade path. The note must also cover two smaller behaviour changes: a whole-blob ciphertext pasted into `secret-values.yaml` now errors instead of decrypting, and a comment attached to an encrypted value is stored in cleartext.
- [ ] Bump `github.com/werf/common-go` in `werf/nelm` (`go.mod:60` pins `v0.0.0-20260428201303-b0dcadceca5c`).
- [ ] Bump `github.com/werf/common-go` in `werf/werf` (`go.mod:62` pins `v0.0.0-20260414103517-0558f83edc6d`). Until then werf keeps writing the unauthenticated format.
- [ ] Close `werf/nelm#677` by hand once the bump lands — a cross-repo `Fixes` reference does not auto-close it.
